### PR TITLE
Require checkbox "oegdproptin_userregistration"

### DIFF
--- a/Application/views/blocks/user_account_newsletter.tpl
+++ b/Application/views/blocks/user_account_newsletter.tpl
@@ -8,7 +8,7 @@
     <div class="col-lg-9 col-lg-offset-3">
         <div class="checkbox">
             <label for="oegdproptin_userregistration">
-                <input type="checkbox" name="oegdproptin_userregistration" id="oegdproptin_userregistration" value="1"> [{oxmultilang ident="OEGDPROPTIN_USER_REGISTRATION_OPTIN"}]
+                <input type="checkbox" name="oegdproptin_userregistration" id="oegdproptin_userregistration" value="1" required="required"> [{oxmultilang ident="OEGDPROPTIN_USER_REGISTRATION_OPTIN"}]
             </label>
         </div>
         [{if $Errors.oegdproptin_userregistration}]


### PR DESCRIPTION
The checkbox "oegdproptin_userregistration" should be required to prevent a submit without accepting the declaration of consent.