### PR TITLE
Fix unclosed elements

### DIFF
--- a/Application/views/blocks/user_checkout_billing_feedback.tpl
+++ b/Application/views/blocks/user_checkout_billing_feedback.tpl
@@ -5,12 +5,12 @@
 [{/if}]
 
 [{if true == $oConfig->getConfigParam('blOeGdprOptinInvoiceAddress')}]
-  <div class="form-group[{if $Errors.oegdproptin_invoiceaddress}] oxInValid[{/if}]" id="GdprInvoiceAddressOptin" class="checkbox" style="display: none;">
+  <div class="form-group[{if $Errors.oegdproptin_invoiceaddress}] oxInValid[{/if}]" id="GdprInvoiceAddressOptin" style="display: none;">
     <div class="col-lg-9 col-lg-offset-3">
       <div class="checkbox">
         <label for="oegdproptin_invoiceaddress">
           <input type="hidden" class="hidden" id="oegdproptin_changeInvAddress" name="oegdproptin_changeInvAddress" value="0">
-          <input type="checkbox" name="oegdproptin_invoiceaddress" id="oegdproptin_invoiceaddress" value="1"> <strong>[{oxmultilang ident="OEGDPROPTIN_STORE_INVOICE_ADDRESS"}]<strong>
+          <input type="checkbox" name="oegdproptin_invoiceaddress" id="oegdproptin_invoiceaddress" value="1"> <strong>[{oxmultilang ident="OEGDPROPTIN_STORE_INVOICE_ADDRESS"}]</strong>
         </label>
       </div>
     </div>

--- a/Application/views/blocks/user_checkout_shipping_feedback.tpl
+++ b/Application/views/blocks/user_checkout_shipping_feedback.tpl
@@ -5,12 +5,12 @@
 [{/if}]
 
 [{if true == $oConfig->getConfigParam('blOeGdprOptinDeliveryAddress')}]
-  <div class="form-group[{if $Errors.oegdproptin_deliveryaddress}] oxInValid[{/if}]" id="GdprOptinShipAddress" class="checkbox" style="display: none;">
+  <div class="form-group[{if $Errors.oegdproptin_deliveryaddress}] oxInValid[{/if}]" id="GdprOptinShipAddress" style="display: none;">
     <div class="col-lg-9 col-lg-offset-3">
       <div class="checkbox">
         <label for="oegdproptin_deliveryaddress">
           <input type="hidden" class="hidden" id="oegdproptin_changeDelAddress" name="oegdproptin_changeDelAddress" value="0">
-          <input type="checkbox" name="oegdproptin_deliveryaddress" id="oegdproptin_deliveryaddress" value="1"> <strong>[{oxmultilang ident="OEGDPROPTIN_STORE_DELIVERY_ADDRESS"}]<strong>
+          <input type="checkbox" name="oegdproptin_deliveryaddress" id="oegdproptin_deliveryaddress" value="1"> <strong>[{oxmultilang ident="OEGDPROPTIN_STORE_DELIVERY_ADDRESS"}]</strong>
         </label>
       </div>
     </div>


### PR DESCRIPTION
Some templates contain unclosed `<strong>` elements, leading to invalid markup and corrupted styles. This commit should take care of that.