### PR TITLE
Check if checkbox should be visible on load

### DIFF
--- a/Application/views/blocks/user_checkout_change.tpl
+++ b/Application/views/blocks/user_checkout_change.tpl
@@ -10,11 +10,15 @@
 
 [{if true == $oConfig->getConfigParam('blOeGdprOptinDeliveryAddress')}]
     [{if $delivadr}]
-        [{oxscript add="$('#showShipAddress').change( function() { $('#GdprOptinShipAddress, #shippingAddressForm').hide($(this).is(':checked'));});"}]
+        [{oxscript add="function toggleGdprOptinShipAddress() { $('#GdprOptinShipAddress, #shippingAddressForm').hide($(this).is(':checked'));}"}]
+        [{oxscript add="$('#showShipAddress').change(toggleGdprOptinShipAddress);"}]
+        [{oxscript add="toggleGdprOptinShipAddress.bind($('#showShipAddress')[0])();"}]
         [{oxscript add="$( '.dd-edit-shipping-address' ).click(function(){ $('#GdprOptinShipAddress').toggle($(this).is(':not(:checked)')); document.getElementById('oegdproptin_changeDelAddress').value=1; });"}]
         [{oxscript add="$( '.dd-add-delivery-address' ).click( function(){ $('#GdprOptinShipAddress').toggle($(this).is(':not(:checked)')); });"}]
     [{else}]
-        [{oxscript add="$('#showShipAddress').change( function() { $('#GdprOptinShipAddress').toggle($(this).is(':not(:checked)')); });"}]
+        [{oxscript add="function toggleGdprOptinShipAddress() { $('#GdprOptinShipAddress').toggle($(this).is(':not(:checked)'));}"}]
+        [{oxscript add="toggleGdprOptinShipAddress.bind($('#showShipAddress')[0])();"}]
+        [{oxscript add="$('#showShipAddress').change(toggleGdprOptinShipAddress);"}]
     [{/if}]
 [{/if}]
 


### PR DESCRIPTION
If user click edit shipping-address gdpr checkbox is visible. On delete shippingaddress or submitting with error it doesnt check again, if gdpr button should be visible, because checkbox is not changed.

This code run function even if #showShipAddress is not changed.